### PR TITLE
refactor: centralize styles and navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,53 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+body {
+  background-color: #fff;
+  background-repeat: no-repeat;
+  background-position: top center;
+  background-size: contain;
+  font-family: Arial, sans-serif;
+}
+.hotspot {
+  position: absolute;
+  cursor: pointer;
+  border-radius: 8px;
+}
+.form-container {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80%;
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.form-container label {
+  font-size: 14px;
+}
+.form-container input {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.form-container button {
+  padding: 10px;
+  border: none;
+  border-radius: 4px;
+  background-color: #007bff;
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+}
+.form-container button:hover {
+  background-color: #0056b3;
+}
+@media (min-width: 768px) {
+  .form-container {
+    max-width: 400px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,30 +1,11 @@
 <!DOCTYPE html>
-
 <html lang="es">
 <head>
-<meta charset="utf-8"/>
-<title>Pantalla1</title>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-    }
-    body {
-      background: url('img/pantalla1.png') no-repeat center top;
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
-    }
-  </style>
+  <meta charset="utf-8"/>
+  <meta http-equiv="refresh" content="0; url=pantalla1.html"/>
+  <title>Redirigiendo</title>
 </head>
 <body>
-
-<div onclick="window.location.href='pantalla3.html'" style="position:absolute;top:57.5%;left:20.51%;width:58%;height:5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+  <p>Redirigiendo a la pantalla principal...</p>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,4 @@
+function login(event) {
+  event.preventDefault();
+  window.location.href = 'pantalla2.html';
+}

--- a/pantalla1.html
+++ b/pantalla1.html
@@ -1,30 +1,24 @@
 <!DOCTYPE html>
-
 <html lang="es">
 <head>
-<meta charset="utf-8"/>
-<title>Pantalla1</title>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-    }
+  <meta charset="utf-8"/>
+  <title>Pantalla1</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" href="css/style.css"/>
+  <style>
     body {
-      background: url('img/pantalla1.png') no-repeat center top;
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      background-image: url('img/pantalla1.png');
     }
   </style>
 </head>
 <body>
-
-<div onclick="window.location.href='pantalla3.html'" style="position:absolute;top:57.2%;left:20.51%;width:58%;height:4.3%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+  <form class="form-container" onsubmit="login(event)">
+    <label for="usuario">Usuario</label>
+    <input type="text" id="usuario" name="usuario" aria-label="Usuario" required>
+    <label for="contrasena">Contraseña</label>
+    <input type="password" id="contrasena" name="contrasena" aria-label="Contraseña" required>
+    <button type="submit">Ingresar</button>
+  </form>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/pantalla10.html
+++ b/pantalla10.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla10</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,16 +17,11 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
 <body>
 
 
-<div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:8%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla1.html'" style="position:absolute;top:80%;left:28.21%;width:41.03%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:8%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla1.html'" style="position:absolute;top:80%;left:28.21%;width:41.03%;height:6%;z-index:999;"></div></body></html>

--- a/pantalla11.html
+++ b/pantalla11.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla11</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -29,4 +25,4 @@
 
 
 
-<div onclick="alert('🚨 Alertas revisadas')" style="position:absolute;top:28%;left:15%;width:60%;height:8%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla1.html'" style="position:absolute;top:85%;left:28.21%;width:41.03%;height:6%;background-color:rgba(255,0,0,0.2);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('🚨 Alertas revisadas')" style="position:absolute;top:28%;left:15%;width:60%;height:8%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:7%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla1.html'" style="position:absolute;top:85%;left:28.21%;width:41.03%;height:6%;z-index:999;"></div></body></html>

--- a/pantalla12.html
+++ b/pantalla12.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla12</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -29,4 +25,4 @@
 
 
 
-<div onclick="alert('🔍 No implementado')" style="position:absolute;top:29.61%;left:15%;width:62%;height:17%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('🔍 Indicador implementado')" style="position:absolute;top:46%;left:17%;width:62%;height:17%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('🔍 No implementado')" style="position:absolute;top:29.61%;left:15%;width:62%;height:17%;z-index:999;"></div><div class="hotspot" onclick="alert('🔍 Indicador implementado')" style="position:absolute;top:46%;left:17%;width:62%;height:17%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:7%;z-index:999;"></div></body></html>

--- a/pantalla2.html
+++ b/pantalla2.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla2</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -35,4 +31,4 @@
 
 
 
-<div onclick="window.location.href='pantalla4.html'" style="position:absolute;top:25%;left:12%;width:60%;height:5.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla3.html'" style="position:absolute;top:31.7%;left:18%;width:29.5%;height:4.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla5.html'" style="position:absolute;top:38%;left:18%;width:29%;height:13.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla8.html'" style="position:absolute;top:38%;left:51%;width:30.8%;height:13.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla6.html'" style="position:absolute;top:53%;left:18%;width:29%;height:12%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla7.html'" style="position:absolute;top:53%;left:51%;width:30.8%;height:12%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla11.html'" style="position:absolute;top:6%;left:12.5%;width:13%;height:7.5%;background-color:rgba(0,0,255,0.5);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla10.html'" style="position:absolute;top:6%;left:73%;width:13%;height:7.5%;background-color:rgba(0,0,255,0.2);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla4.html'" style="position:absolute;top:68.5%;left:22%;width:56%;height:6%;background-color:rgba(0,0,255,0.5);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla1.html'" style="position:absolute;top:77%;left:22%;width:56%;height:5.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla4.html'" style="position:absolute;top:25%;left:12%;width:60%;height:5.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla3.html'" style="position:absolute;top:31.7%;left:18%;width:29.5%;height:4.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla5.html'" style="position:absolute;top:38%;left:18%;width:29%;height:13.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla8.html'" style="position:absolute;top:38%;left:51%;width:30.8%;height:13.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla6.html'" style="position:absolute;top:53%;left:18%;width:29%;height:12%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla7.html'" style="position:absolute;top:53%;left:51%;width:30.8%;height:12%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla11.html'" style="position:absolute;top:6%;left:12.5%;width:13%;height:7.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla10.html'" style="position:absolute;top:6%;left:73%;width:13%;height:7.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla4.html'" style="position:absolute;top:68.5%;left:22%;width:56%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla1.html'" style="position:absolute;top:77%;left:22%;width:56%;height:5.5%;z-index:999;"></div></body></html>

--- a/pantalla3.html
+++ b/pantalla3.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla3</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,15 +17,10 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
 <body>
 
-<div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:38%;left:14%;width:65%;height:20%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:38%;left:14%;width:65%;height:20%;z-index:999;"></div></body></html>

--- a/pantalla4.html
+++ b/pantalla4.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla4</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -29,4 +25,4 @@
 
 
 
-<div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:10%;left:12%;width:15%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla5.html'" style="position:absolute;top:75%;left:12%;width:30%;height:8%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla8.html'" style="position:absolute;top:75%;left:51.28%;width:30%;height:8%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:10%;left:12%;width:15%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla5.html'" style="position:absolute;top:75%;left:12%;width:30%;height:8%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla8.html'" style="position:absolute;top:75%;left:51.28%;width:30%;height:8%;z-index:999;"></div></body></html>

--- a/pantalla5.html
+++ b/pantalla5.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla5</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -30,4 +26,4 @@
 
 
 
-<div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:25%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:31%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:37%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:43%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📤 Informe enviado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:6%;left:13%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('✅ Checklist marcado')" style="position:absolute;top:25%;left:15%;width:40%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('✅ Checklist marcado')" style="position:absolute;top:31%;left:15%;width:40%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('✅ Checklist marcado')" style="position:absolute;top:37%;left:15%;width:40%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('✅ Checklist marcado')" style="position:absolute;top:43%;left:15%;width:40%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('📤 Informe enviado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:6%;left:13%;width:15%;height:7%;z-index:999;"></div></body></html>

--- a/pantalla6.html
+++ b/pantalla6.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla6</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -30,4 +26,4 @@
 
 
 
-<div onclick="alert('📄 Aprobando...')" style="position:absolute;top:72%;left:17%;width:25.64%;height:6.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Observación enviada')" style="position:absolute;top:72%;left:53%;width:25.64%;height:6.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla1.html'" style="position:absolute;top:79%;left:28.21%;width:41.03%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('📄 Aprobando...')" style="position:absolute;top:72%;left:17%;width:25.64%;height:6.5%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Observación enviada')" style="position:absolute;top:72%;left:53%;width:25.64%;height:6.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla1.html'" style="position:absolute;top:79%;left:28.21%;width:41.03%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;z-index:999;"></div></body></html>

--- a/pantalla7.html
+++ b/pantalla7.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla7</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -30,4 +26,4 @@
 
 
 
-<div onclick="window.location.href='pantalla12.html'" style="position:absolute;top:58%;left:18.5%;width:45%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla12.html'" style="position:absolute;top:64%;left:18.5%;width:45%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Informe generado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📄 Generando PDF...')" style="position:absolute;top:75%;left:15.38%;width:25.64%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Generando Excel...')" style="position:absolute;top:75%;left:51.28%;width:25.64%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla12.html'" style="position:absolute;top:58%;left:18.5%;width:45%;height:7%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla12.html'" style="position:absolute;top:64%;left:18.5%;width:45%;height:7%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Informe generado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:5%;z-index:999;"></div><div class="hotspot" onclick="alert('📄 Generando PDF...')" style="position:absolute;top:75%;left:15.38%;width:25.64%;height:6%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Generando Excel...')" style="position:absolute;top:75%;left:51.28%;width:25.64%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;z-index:999;"></div></body></html>

--- a/pantalla8.html
+++ b/pantalla8.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla8</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -31,4 +27,4 @@
 
 
 
-<div onclick="alert('📷 Foto adjunta')" style="position:absolute;top:20%;left:15%;width:60%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📷 Foto adjunta')" style="position:absolute;top:32%;left:15%;width:60%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📷 Foto adjunta')" style="position:absolute;top:42%;left:15%;width:60%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📷 Foto adjunta')" style="position:absolute;top:52%;left:15%;width:60%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Checklist confirmado')" style="position:absolute;top:75%;left:25.64%;width:51.28%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('📷 Foto adjunta')" style="position:absolute;top:20%;left:15%;width:60%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('📷 Foto adjunta')" style="position:absolute;top:32%;left:15%;width:60%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('📷 Foto adjunta')" style="position:absolute;top:42%;left:15%;width:60%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('📷 Foto adjunta')" style="position:absolute;top:52%;left:15%;width:60%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Checklist confirmado')" style="position:absolute;top:75%;left:25.64%;width:51.28%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;z-index:999;"></div></body></html>

--- a/pantalla9.html
+++ b/pantalla9.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla9</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,16 +17,11 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
 <body>
 
 
-<div onclick="alert('✅ Modo offline')" style="position:absolute;top:50%;left:25.64%;width:51.28%;height:4.74%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:58%;left:25.64%;width:51.28%;height:4.74%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('✅ Modo offline')" style="position:absolute;top:50%;left:25.64%;width:51.28%;height:4.74%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:58%;left:25.64%;width:51.28%;height:4.74%;z-index:999;"></div></body></html>


### PR DESCRIPTION
## Summary
- redirect root index to Pantalla1 login screen
- consolidate hotspot styling across screens via shared stylesheet
- simplify navigation hotspots by removing inline background colors

## Testing
- `node -e "require('./js/main.js')"`


------
https://chatgpt.com/codex/tasks/task_e_6896dd9fb0ac8322a981947b6b2912ae