### PR TITLE
feat: add interactive activity forms and index gallery

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,109 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+body {
+  background-color: #fff;
+  background-repeat: no-repeat;
+  background-position: top center;
+  background-size: contain;
+  font-family: Arial, sans-serif;
+}
+.hotspot {
+  position: absolute;
+  cursor: pointer;
+  border-radius: 8px;
+}
+.form-container {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80%;
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.form-container label {
+  font-size: 14px;
+}
+.form-container input {
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.form-container button {
+  padding: 10px;
+  border: none;
+  border-radius: 4px;
+  background-color: #007bff;
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+}
+.form-container button:hover {
+  background-color: #0056b3;
+}
+@media (min-width: 768px) {
+  .form-container {
+    max-width: 400px;
+  }
+}
+
+/* modal styles for pantalla5 popups */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.6);
+  z-index: 1000;
+}
+.modal.hidden {
+  display: none;
+}
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: 80%;
+  max-width: 400px;
+}
+.modal-content input,
+.modal-content textarea {
+  width: 100%;
+  margin-bottom: 10px;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.modal-content button {
+  margin-right: 10px;
+  padding: 8px 16px;
+}
+.info {
+  position: absolute;
+  color: #000;
+  font-weight: bold;
+}
+#fotos-container {
+  position: absolute;
+  top: 70%;
+  left: 5%;
+  right: 5%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+#fotos-container img {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 4px;
+}

--- a/index.html
+++ b/index.html
@@ -1,30 +1,93 @@
 <!DOCTYPE html>
-
 <html lang="es">
 <head>
-<meta charset="utf-8"/>
-<title>Pantalla1</title>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-    }
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Contenido</title>
+  <link rel="stylesheet" href="css/style.css"/>
+  <style>
     body {
-      background: url('img/pantalla1.png') no-repeat center top;
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: top;
-      background-color: #fff;
+      padding: 20px;
     }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      gap: 20px;
+    }
+    a.card {
+      text-decoration: none;
+      color: inherit;
+      display: block;
+    }
+    a.card:hover { box-shadow: 0 6px 18px rgba(0,0,0,.08); }
+    a.card:active { transform: translateY(1px); }
+    .thumb {
+      width: 100%;
+      aspect-ratio: 9/16;
+      object-fit: cover;
       border-radius: 8px;
+      background: #f3f4f6;
+    }
+    .title {
+      margin-top: 8px;
+      font-weight: 600;
+      font-size: 14px;
+      text-align: center;
     }
   </style>
 </head>
 <body>
+  <h1>Pantallas</h1>
+  <div class="grid">
+    <a class="card" href="pantalla1.html">
+      <img class="thumb" src="img/pantalla1.png" alt="Pantalla 1"/>
+      <div class="title">Pantalla 1</div>
+    </a>
+    <a class="card" href="pantalla2.html">
+      <img class="thumb" src="img/pantalla2.png" alt="Pantalla 2"/>
+      <div class="title">Pantalla 2</div>
+    </a>
+    <a class="card" href="pantalla3.html">
+      <img class="thumb" src="img/pantalla3.png" alt="Pantalla 3"/>
+      <div class="title">Pantalla 3</div>
+    </a>
+    <a class="card" href="pantalla4.html">
+      <img class="thumb" src="img/pantalla4.png" alt="Pantalla 4"/>
+      <div class="title">Pantalla 4</div>
+    </a>
+    <a class="card" href="pantalla5.html">
+      <img class="thumb" src="img/pantalla5.png" alt="Pantalla 5"/>
+      <div class="title">Pantalla 5</div>
+    </a>
+    <a class="card" href="pantalla6.html">
+      <img class="thumb" src="img/pantalla6.png" alt="Pantalla 6"/>
+      <div class="title">Pantalla 6</div>
+    </a>
+    <a class="card" href="pantalla7.html">
+      <img class="thumb" src="img/pantalla7.png" alt="Pantalla 7"/>
+      <div class="title">Pantalla 7</div>
+    </a>
+    <a class="card" href="pantalla8.html">
+      <img class="thumb" src="img/pantalla8.png" alt="Pantalla 8"/>
+      <div class="title">Pantalla 8</div>
+    </a>
+    <a class="card" href="pantalla9.html">
+      <img class="thumb" src="img/pantalla9.png" alt="Pantalla 9"/>
+      <div class="title">Pantalla 9</div>
+    </a>
+    <a class="card" href="pantalla10.html">
+      <img class="thumb" src="img/pantalla10.png" alt="Pantalla 10"/>
+      <div class="title">Pantalla 10</div>
+    </a>
+    <a class="card" href="pantalla11.html">
+      <img class="thumb" src="img/pantalla11.png" alt="Pantalla 11"/>
+      <div class="title">Pantalla 11</div>
+    </a>
+    <a class="card" href="pantalla12.html">
+      <img class="thumb" src="img/pantalla12.png" alt="Pantalla 12"/>
+      <div class="title">Pantalla 12</div>
+    </a>
+  </div>
+</body>
+</html>
 
-<div onclick="window.location.href='pantalla3.html'" style="position:absolute;top:57.5%;left:20.51%;width:58%;height:5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>

--- a/instrucciones.pdf
+++ b/instrucciones.pdf
@@ -1,0 +1,18 @@
+%PDF-1.1
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R >> endobj
+4 0 obj << /Length 44 >> stream
+BT /F1 24 Tf 100 100 Td (Instrucciones) Tj ET
+endstream endobj
+xref
+0 5
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000116 00000 n 
+0000000211 00000 n 
+trailer << /Size 5 /Root 1 0 R >>
+startxref
+309
+%%EOF

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,193 @@
+function login(event) {
+  event.preventDefault();
+  window.location.href = 'pantalla2.html';
+}
+
+function $(id){return document.getElementById(id);}
+
+function openModal(builder){
+  const modal=$('modal');
+  const content=$('modal-content');
+  content.innerHTML='';
+  builder(content);
+  modal.classList.remove('hidden');
+}
+
+function closeModal(){
+  $('modal').classList.add('hidden');
+}
+
+function createButtons(onCancel,onSave){
+  const wrapper=document.createElement('div');
+  const cancel=document.createElement('button');
+  cancel.textContent='Cancelar';
+  cancel.onclick=onCancel;
+  const save=document.createElement('button');
+  save.textContent='Guardar';
+  save.onclick=onSave;
+  wrapper.appendChild(cancel);
+  wrapper.appendChild(save);
+  return wrapper;
+}
+
+function openClima(){
+  openModal(content=>{
+    const textarea=document.createElement('textarea');
+    textarea.value=localStorage.getItem('clima')||'';
+    content.appendChild(textarea);
+    content.appendChild(createButtons(closeModal,()=>{
+      localStorage.setItem('clima',textarea.value);
+      alert('guardado con éxito');
+      closeModal();
+    }));
+  });
+}
+
+function openPersonal(){
+  openModal(content=>{
+    const num=document.createElement('input');
+    num.type='number';
+    num.value=localStorage.getItem('personalCantidad')||'';
+    const obs=document.createElement('textarea');
+    obs.placeholder='Observaciones';
+    obs.value=localStorage.getItem('personalObs')||'';
+    content.appendChild(num);
+    content.appendChild(obs);
+    content.appendChild(createButtons(closeModal,()=>{
+      localStorage.setItem('personalCantidad',num.value);
+      localStorage.setItem('personalObs',obs.value);
+      alert('guardado con éxito');
+      if($('personal-info')) $('personal-info').textContent='Personal presente: '+num.value;
+      closeModal();
+    }));
+  });
+}
+
+function openMaquina(){
+  openModal(content=>{
+    const desc=document.createElement('textarea');
+    desc.placeholder='Descripción de la máquina';
+    desc.value=localStorage.getItem('maquinaDesc')||'';
+    const file=document.createElement('input');
+    file.type='file';
+    file.accept='image/*';
+    file.multiple=true;
+    content.appendChild(desc);
+    content.appendChild(file);
+    const existing=JSON.parse(localStorage.getItem('maquinaFotos')||'[]');
+    existing.forEach(src=>{
+      const img=document.createElement('img');
+      img.src=src; img.style.width='60px'; img.style.marginRight='5px';
+      content.appendChild(img);
+    });
+    content.appendChild(createButtons(closeModal,()=>{
+      localStorage.setItem('maquinaDesc',desc.value);
+      if(file.files.length>0){
+        const readers=[];
+        for(const f of file.files){
+          const r=new FileReader();
+          readers.push(new Promise(res=>{r.onload=e=>res(e.target.result);r.readAsDataURL(f);}));
+        }
+        Promise.all(readers).then(images=>{
+          const all=existing.concat(images);
+          localStorage.setItem('maquinaFotos',JSON.stringify(all));
+          displayAllPhotos();
+        });
+      } else {
+        displayAllPhotos();
+      }
+      alert('guardado con éxito');
+      closeModal();
+    }));
+  });
+}
+
+function openAvance(){
+  openModal(content=>{
+    const input=document.createElement('input');
+    input.type='number';
+    input.placeholder='%';
+    input.value=localStorage.getItem('avance')||'';
+    content.appendChild(input);
+    content.appendChild(createButtons(closeModal,()=>{
+      localStorage.setItem('avance',input.value);
+      alert('guardado con éxito');
+      if($('avance-info')) $('avance-info').textContent='Avance físico: '+input.value+'%';
+      closeModal();
+    }));
+  });
+}
+
+function openInstrucciones(){
+  window.open('instrucciones.pdf','_blank');
+}
+
+function openVientos(){
+  openModal(content=>{
+    const textarea=document.createElement('textarea');
+    textarea.placeholder='Descripción';
+    textarea.value=localStorage.getItem('vientos')||'';
+    content.appendChild(textarea);
+    content.appendChild(createButtons(closeModal,()=>{
+      localStorage.setItem('vientos',textarea.value);
+      alert('guardado con éxito');
+      closeModal();
+    }));
+  });
+}
+
+function openFotos(){
+  openModal(content=>{
+    const file=document.createElement('input');
+    file.type='file';
+    file.accept='image/*';
+    file.capture='environment';
+    file.multiple=true;
+    content.appendChild(file);
+    content.appendChild(createButtons(closeModal,()=>{
+      if(file.files.length>0){
+        const readers=[];
+        for(const f of file.files){
+          const r=new FileReader();
+          readers.push(new Promise(res=>{r.onload=e=>res(e.target.result);r.readAsDataURL(f);}));
+        }
+        Promise.all(readers).then(images=>{
+          const existing=JSON.parse(localStorage.getItem('extraFotos')||'[]');
+          const all=existing.concat(images);
+          localStorage.setItem('extraFotos',JSON.stringify(all));
+          displayAllPhotos();
+        });
+      }
+      alert('guardado con éxito');
+      closeModal();
+    }));
+  });
+}
+
+function displayAllPhotos(){
+  const container=$('fotos-container');
+  if(!container) return;
+  container.innerHTML='';
+  const all=[...JSON.parse(localStorage.getItem('maquinaFotos')||'[]'),
+             ...JSON.parse(localStorage.getItem('extraFotos')||'[]')];
+  all.forEach(src=>{
+    const img=document.createElement('img');
+    img.src=src;
+    container.appendChild(img);
+  });
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    if ($('personal-info')) {
+      const c = localStorage.getItem('personalCantidad');
+      if (c) $('personal-info').textContent = 'Personal presente: ' + c;
+    }
+    if ($('avance-info')) {
+      const a = localStorage.getItem('avance');
+      if (a) $('avance-info').textContent = 'Avance físico: ' + a + '%';
+    }
+    displayAllPhotos();
+  });
+}
+

--- a/pantalla1.html
+++ b/pantalla1.html
@@ -1,30 +1,24 @@
 <!DOCTYPE html>
-
 <html lang="es">
 <head>
-<meta charset="utf-8"/>
-<title>Pantalla1</title>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-    }
+  <meta charset="utf-8"/>
+  <title>Pantalla1</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" href="css/style.css"/>
+  <style>
     body {
-      background: url('img/pantalla1.png') no-repeat center top;
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      background-image: url('img/pantalla1.png');
     }
   </style>
 </head>
 <body>
-
-<div onclick="window.location.href='pantalla3.html'" style="position:absolute;top:57.2%;left:20.51%;width:58%;height:4.3%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+  <form class="form-container" onsubmit="login(event)">
+    <label for="usuario">Usuario</label>
+    <input type="text" id="usuario" name="usuario" aria-label="Usuario" required>
+    <label for="contrasena">Contraseña</label>
+    <input type="password" id="contrasena" name="contrasena" aria-label="Contraseña" required>
+    <button type="submit">Ingresar</button>
+  </form>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/pantalla10.html
+++ b/pantalla10.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla10</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,16 +17,11 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
 <body>
 
 
-<div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:8%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla1.html'" style="position:absolute;top:80%;left:28.21%;width:41.03%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:8%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla1.html'" style="position:absolute;top:80%;left:28.21%;width:41.03%;height:6%;z-index:999;"></div></body></html>

--- a/pantalla11.html
+++ b/pantalla11.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla11</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -29,4 +25,4 @@
 
 
 
-<div onclick="alert('🚨 Alertas revisadas')" style="position:absolute;top:28%;left:15%;width:60%;height:8%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla1.html'" style="position:absolute;top:85%;left:28.21%;width:41.03%;height:6%;background-color:rgba(255,0,0,0.2);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('🚨 Alertas revisadas')" style="position:absolute;top:28%;left:15%;width:60%;height:8%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:7%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla1.html'" style="position:absolute;top:85%;left:28.21%;width:41.03%;height:6%;z-index:999;"></div></body></html>

--- a/pantalla12.html
+++ b/pantalla12.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla12</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -29,4 +25,4 @@
 
 
 
-<div onclick="alert('🔍 No implementado')" style="position:absolute;top:29.61%;left:15%;width:62%;height:17%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('🔍 Indicador implementado')" style="position:absolute;top:46%;left:17%;width:62%;height:17%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('🔍 No implementado')" style="position:absolute;top:29.61%;left:15%;width:62%;height:17%;z-index:999;"></div><div class="hotspot" onclick="alert('🔍 Indicador implementado')" style="position:absolute;top:46%;left:17%;width:62%;height:17%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:12%;height:7%;z-index:999;"></div></body></html>

--- a/pantalla2.html
+++ b/pantalla2.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla2</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -35,4 +31,4 @@
 
 
 
-<div onclick="window.location.href='pantalla4.html'" style="position:absolute;top:25%;left:12%;width:60%;height:5.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla3.html'" style="position:absolute;top:31.7%;left:18%;width:29.5%;height:4.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla5.html'" style="position:absolute;top:38%;left:18%;width:29%;height:13.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla8.html'" style="position:absolute;top:38%;left:51%;width:30.8%;height:13.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla6.html'" style="position:absolute;top:53%;left:18%;width:29%;height:12%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla7.html'" style="position:absolute;top:53%;left:51%;width:30.8%;height:12%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla11.html'" style="position:absolute;top:6%;left:12.5%;width:13%;height:7.5%;background-color:rgba(0,0,255,0.5);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla10.html'" style="position:absolute;top:6%;left:73%;width:13%;height:7.5%;background-color:rgba(0,0,255,0.2);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla4.html'" style="position:absolute;top:68.5%;left:22%;width:56%;height:6%;background-color:rgba(0,0,255,0.5);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla1.html'" style="position:absolute;top:77%;left:22%;width:56%;height:5.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla4.html'" style="position:absolute;top:25%;left:12%;width:60%;height:5.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla3.html'" style="position:absolute;top:31.7%;left:18%;width:29.5%;height:4.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla5.html'" style="position:absolute;top:38%;left:18%;width:29%;height:13.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla8.html'" style="position:absolute;top:38%;left:51%;width:30.8%;height:13.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla6.html'" style="position:absolute;top:53%;left:18%;width:29%;height:12%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla7.html'" style="position:absolute;top:53%;left:51%;width:30.8%;height:12%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla11.html'" style="position:absolute;top:6%;left:12.5%;width:13%;height:7.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla10.html'" style="position:absolute;top:6%;left:73%;width:13%;height:7.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla4.html'" style="position:absolute;top:68.5%;left:22%;width:56%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla1.html'" style="position:absolute;top:77%;left:22%;width:56%;height:5.5%;z-index:999;"></div></body></html>

--- a/pantalla3.html
+++ b/pantalla3.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla3</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,15 +17,10 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
 <body>
 
-<div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:38%;left:14%;width:65%;height:20%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:38%;left:14%;width:65%;height:20%;z-index:999;"></div></body></html>

--- a/pantalla4.html
+++ b/pantalla4.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla4</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -29,4 +25,4 @@
 
 
 
-<div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:10%;left:12%;width:15%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla5.html'" style="position:absolute;top:75%;left:12%;width:30%;height:8%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla8.html'" style="position:absolute;top:75%;left:51.28%;width:30%;height:8%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:10%;left:12%;width:15%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla5.html'" style="position:absolute;top:75%;left:12%;width:30%;height:8%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla8.html'" style="position:absolute;top:75%;left:51.28%;width:30%;height:8%;z-index:999;"></div></body></html>

--- a/pantalla5.html
+++ b/pantalla5.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla5</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,18 +17,27 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
 <body>
+  <!-- hotspots for activity registration -->
+  <div class="hotspot" style="top:25%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openClima()"></div>
+  <div class="hotspot" style="top:31%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openPersonal()"></div>
+  <div class="hotspot" style="top:37%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openMaquina()"></div>
+  <div class="hotspot" style="top:43%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openAvance()"></div>
+  <div class="hotspot" style="top:49%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openInstrucciones()"></div>
+  <div class="hotspot" style="top:55%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openVientos()"></div>
+  <div class="hotspot" style="top:61%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openFotos()"></div>
+  <div class="hotspot" style="top:82%;left:25.64%;width:51.28%;height:6%;z-index:999;" onclick="alert('📤 Informe enviado')"></div>
+  <div class="hotspot" style="top:6%;left:13%;width:15%;height:7%;z-index:999;" onclick="window.location.href='pantalla2.html'"></div>
 
+  <div id="personal-info" class="info" style="top:31%;left:60%;"></div>
+  <div id="avance-info" class="info" style="top:43%;left:60%;"></div>
+  <div id="fotos-container"></div>
 
-
-
-<div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:25%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:31%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:37%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:43%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📤 Informe enviado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:6%;left:13%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+  <div id="modal" class="modal hidden"><div id="modal-content" class="modal-content"></div></div>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/pantalla6.html
+++ b/pantalla6.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla6</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -30,4 +26,4 @@
 
 
 
-<div onclick="alert('📄 Aprobando...')" style="position:absolute;top:72%;left:17%;width:25.64%;height:6.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Observación enviada')" style="position:absolute;top:72%;left:53%;width:25.64%;height:6.5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla1.html'" style="position:absolute;top:79%;left:28.21%;width:41.03%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('📄 Aprobando...')" style="position:absolute;top:72%;left:17%;width:25.64%;height:6.5%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Observación enviada')" style="position:absolute;top:72%;left:53%;width:25.64%;height:6.5%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla1.html'" style="position:absolute;top:79%;left:28.21%;width:41.03%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;z-index:999;"></div></body></html>

--- a/pantalla7.html
+++ b/pantalla7.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla7</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -30,4 +26,4 @@
 
 
 
-<div onclick="window.location.href='pantalla12.html'" style="position:absolute;top:58%;left:18.5%;width:45%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla12.html'" style="position:absolute;top:64%;left:18.5%;width:45%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Informe generado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📄 Generando PDF...')" style="position:absolute;top:75%;left:15.38%;width:25.64%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Generando Excel...')" style="position:absolute;top:75%;left:51.28%;width:25.64%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="window.location.href='pantalla12.html'" style="position:absolute;top:58%;left:18.5%;width:45%;height:7%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla12.html'" style="position:absolute;top:64%;left:18.5%;width:45%;height:7%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Informe generado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:5%;z-index:999;"></div><div class="hotspot" onclick="alert('📄 Generando PDF...')" style="position:absolute;top:75%;left:15.38%;width:25.64%;height:6%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Generando Excel...')" style="position:absolute;top:75%;left:51.28%;width:25.64%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;z-index:999;"></div></body></html>

--- a/pantalla8.html
+++ b/pantalla8.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla8</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,12 +17,7 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
@@ -31,4 +27,4 @@
 
 
 
-<div onclick="alert('📷 Foto adjunta')" style="position:absolute;top:20%;left:15%;width:60%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📷 Foto adjunta')" style="position:absolute;top:32%;left:15%;width:60%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📷 Foto adjunta')" style="position:absolute;top:42%;left:15%;width:60%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📷 Foto adjunta')" style="position:absolute;top:52%;left:15%;width:60%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Checklist confirmado')" style="position:absolute;top:75%;left:25.64%;width:51.28%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('📷 Foto adjunta')" style="position:absolute;top:20%;left:15%;width:60%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('📷 Foto adjunta')" style="position:absolute;top:32%;left:15%;width:60%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('📷 Foto adjunta')" style="position:absolute;top:42%;left:15%;width:60%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('📷 Foto adjunta')" style="position:absolute;top:52%;left:15%;width:60%;height:3.55%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Checklist confirmado')" style="position:absolute;top:75%;left:25.64%;width:51.28%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;z-index:999;"></div></body></html>

--- a/pantalla9.html
+++ b/pantalla9.html
@@ -5,6 +5,7 @@
 <meta charset="utf-8"/>
 <title>Pantalla9</title>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<link rel="stylesheet" href="css/style.css"/>
 <style>
     html, body {
       margin: 0;
@@ -16,16 +17,11 @@
       background-size: contain;
       background-repeat: no-repeat;
       background-position: top;
-      background-color: #fff;
-    }
-    .hotspot {
-      position: absolute;
-      cursor: pointer;
-      border-radius: 8px;
+      
     }
   </style>
 </head>
 <body>
 
 
-<div onclick="alert('✅ Modo offline')" style="position:absolute;top:50%;left:25.64%;width:51.28%;height:4.74%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:58%;left:25.64%;width:51.28%;height:4.74%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
+<div class="hotspot" onclick="alert('✅ Modo offline')" style="position:absolute;top:50%;left:25.64%;width:51.28%;height:4.74%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:58%;left:25.64%;width:51.28%;height:4.74%;z-index:999;"></div></body></html>


### PR DESCRIPTION
## Summary
- add reusable modal and localStorage helpers for climate, personnel, machinery, progress, wind, and photo reports
- wire pantalla5 hotspots to open forms, display stored values, and link to technical instructions PDF
- style modal and photo gallery elements for interactive popups
- replace redirecting index with a responsive grid of thumbnail links to every prototype screen

## Testing
- `node -e "require('./js/main.js')"`


------
https://chatgpt.com/codex/tasks/task_e_6896dd9fb0ac8322a981947b6b2912ae