### PR TITLE
Add PDF report generation for pantalla5

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -191,3 +191,53 @@ if (typeof document !== 'undefined') {
   });
 }
 
+function generatePantalla5PDF(){
+  const { jsPDF } = window.jspdf || {};
+  if(!jsPDF){
+    alert('jsPDF no disponible');
+    return;
+  }
+  const doc = new jsPDF();
+  let y = 10;
+  const clima = localStorage.getItem('clima');
+  if (clima) { doc.text('Clima: ' + clima, 10, y); y += 10; }
+  const personal = localStorage.getItem('personalCantidad');
+  if (personal) { doc.text('Personal: ' + personal, 10, y); y += 10; }
+  const avance = localStorage.getItem('avance');
+  if (avance) { doc.text('Avance físico: ' + avance + '%', 10, y); y += 10; }
+  const vientos = localStorage.getItem('vientos');
+  if (vientos) { doc.text('Vientos: ' + vientos, 10, y); y += 10; }
+  const maquinaDesc = localStorage.getItem('maquinaDesc');
+  if (maquinaDesc) { doc.text('Maquinaria: ' + maquinaDesc, 10, y); y += 10; }
+  const imgs=[...JSON.parse(localStorage.getItem('maquinaFotos')||'[]'),
+              ...JSON.parse(localStorage.getItem('extraFotos')||'[]')];
+  imgs.forEach(src=>{
+    if (y > 270) { doc.addPage(); y = 10; }
+    try {
+      doc.addImage(src, 'JPEG', 10, y, 180, 100);
+      y += 105;
+    } catch(e) {
+      console.error('No se pudo agregar la imagen al PDF', e);
+    }
+  });
+  const dataUri = doc.output('datauristring');
+  localStorage.setItem('pantalla5pdf', dataUri);
+  alert('Informe generado');
+}
+
+function exportPantalla5PDF(){
+  const data = localStorage.getItem('pantalla5pdf');
+  if(!data){
+    alert('No hay informe generado');
+    return;
+  }
+  const link=document.createElement('a');
+  link.href=data;
+  link.download='informe.pdf';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  alert('PDF exportado');
+  localStorage.removeItem('pantalla5pdf');
+}
+

--- a/pantalla5.html
+++ b/pantalla5.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
-
 <html lang="es">
 <head>
-<meta charset="utf-8"/>
-<title>Pantalla5</title>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<link rel="stylesheet" href="css/style.css"/>
-<style>
+  <meta charset="utf-8"/>
+  <title>Pantalla5</title>
+  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+  <link rel="stylesheet" href="css/style.css"/>
+  <style>
     html, body {
       margin: 0;
       padding: 0;
@@ -23,7 +22,6 @@
       position: absolute;
       cursor: pointer;
       border-radius: 8px;
-      
     }
   </style>
 </head>
@@ -36,17 +34,17 @@
   <div class="hotspot" style="top:49%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openInstrucciones()"></div>
   <div class="hotspot" style="top:55%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openVientos()"></div>
   <div class="hotspot" style="top:61%;left:15%;width:40%;height:3.55%;z-index:999;" onclick="openFotos()"></div>
-  <div class="hotspot" style="top:82%;left:25.64%;width:51.28%;height:6%;z-index:999;" onclick="alert('📤 Informe enviado')"></div>
+  <div class="hotspot" style="top:82%;left:25.64%;width:51.28%;height:6%;z-index:999;" onclick="generatePantalla5PDF()"></div>
   <div class="hotspot" style="top:6%;left:13%;width:15%;height:7%;z-index:999;" onclick="window.location.href='pantalla2.html'"></div>
 
   <div id="personal-info" class="info" style="top:31%;left:60%;"></div>
   <div id="avance-info" class="info" style="top:43%;left:60%;"></div>
   <div id="fotos-container"></div>
 
-
-
-<div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:25%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:31%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:37%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('✅ Checklist marcado')" style="position:absolute;top:43%;left:15%;width:40%;height:3.55%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📤 Informe enviado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:6%;left:13%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
   <div id="modal" class="modal hidden"><div id="modal-content" class="modal-content"></div></div>
+
   <script src="js/main.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </body>
 </html>
+

--- a/pantalla7.html
+++ b/pantalla7.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
-
 <html lang="es">
 <head>
-<meta charset="utf-8"/>
-<title>Pantalla7</title>
-<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<link rel="stylesheet" href="css/style.css"/>
-<style>
+  <meta charset="utf-8"/>
+  <title>Pantalla7</title>
+  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+  <link rel="stylesheet" href="css/style.css"/>
+  <style>
     html, body {
       margin: 0;
       padding: 0;
@@ -23,15 +22,20 @@
       position: absolute;
       cursor: pointer;
       border-radius: 8px;
-      
     }
   </style>
 </head>
 <body>
+  <div class="hotspot" style="top:58%;left:18.5%;width:45%;height:7%;z-index:999;" onclick="window.location.href='pantalla12.html'"></div>
+  <div class="hotspot" style="top:64%;left:18.5%;width:45%;height:7%;z-index:999;" onclick="window.location.href='pantalla12.html'"></div>
+  <div class="hotspot" style="top:82%;left:25.64%;width:51.28%;height:5%;z-index:999;" onclick="alert('📊 Informe generado')"></div>
+  <div class="hotspot" style="top:75%;left:15.38%;width:25.64%;height:6%;z-index:999;" onclick="exportPantalla5PDF()"></div>
+  <div class="hotspot" style="top:75%;left:51.28%;width:25.64%;height:6%;z-index:999;" onclick="alert('📊 Generando Excel...')"></div>
+  <div class="hotspot" style="top:8%;left:12%;width:15%;height:7%;z-index:999;" onclick="window.location.href='pantalla2.html'"></div>
 
+  <div id="modal" class="modal hidden"><div id="modal-content" class="modal-content"></div></div>
 
+  <script src="js/main.js"></script>
+</body>
+</html>
 
-
-<div onclick="window.location.href='pantalla12.html'" style="position:absolute;top:58%;left:18.5%;width:45%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla12.html'" style="position:absolute;top:64%;left:18.5%;width:45%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Informe generado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:5%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📄 Generando PDF...')" style="position:absolute;top:75%;left:15.38%;width:25.64%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="alert('📊 Generando Excel...')" style="position:absolute;top:75%;left:51.28%;width:25.64%;height:6%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div><div onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;background-color:rgba(255,0,0,0.1);z-index:999;cursor:pointer;"></div></body></html>
-<div class="hotspot" onclick="window.location.href='pantalla12.html'" style="position:absolute;top:58%;left:18.5%;width:45%;height:7%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla12.html'" style="position:absolute;top:64%;left:18.5%;width:45%;height:7%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Informe generado')" style="position:absolute;top:82%;left:25.64%;width:51.28%;height:5%;z-index:999;"></div><div class="hotspot" onclick="alert('📄 Generando PDF...')" style="position:absolute;top:75%;left:15.38%;width:25.64%;height:6%;z-index:999;"></div><div class="hotspot" onclick="alert('📊 Generando Excel...')" style="position:absolute;top:75%;left:51.28%;width:25.64%;height:6%;z-index:999;"></div><div class="hotspot" onclick="window.location.href='pantalla2.html'" style="position:absolute;top:8%;left:12%;width:15%;height:7%;z-index:999;"></div>  <script src="js/main.js"></script>
-</body></html>


### PR DESCRIPTION
## Summary
- Clean up hotspot markup in pantalla5 and pantalla7
- Generate PDF report with jsPDF from pantalla5 data and images
- Add export function on pantalla7 to download the stored PDF

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979b49f31c83228cce7af5aa97bfd7